### PR TITLE
Bugfix: Gripper Calibration mode config 

### DIFF
--- a/src/xs_driver.cpp
+++ b/src/xs_driver.cpp
@@ -718,7 +718,7 @@ bool InterbotixDriverXS::get_joint_states(
           gripper_map[joint_name].calibration_offset);
         double pos = convert_angular_position_to_linear(
           joint_name,
-          positions->at(get_js_index(joint_name)) + gripper_map[joint_name].calibration_offset);
+          positions->at(get_js_index(joint_name)));
         positions->push_back(pos);
         positions->push_back(-pos);
       } else {

--- a/src/xs_driver.cpp
+++ b/src/xs_driver.cpp
@@ -715,7 +715,6 @@ bool InterbotixDriverXS::get_joint_states(
       if (is_motor_gripper(joint_name)) {
         positions->push_back(
           robot_positions.at(get_js_index(joint_name)));
-          // gripper_map[joint_name].calibration_offset);
         double pos = convert_angular_position_to_linear(
           joint_name,
           positions->at(get_js_index(joint_name)));


### PR DESCRIPTION
This PR fixes the bug of incorrect calibration due to different mode config parameter of **`operating mode`** in files. This is fixed by changing the order of execution of functions and manually setting the **`operating mode`** as **`pwm`** in calibration routine.