### PR TITLE
[xs_driver] Fix incorrect homing offset in calibration code

### DIFF
--- a/src/xs_driver.cpp
+++ b/src/xs_driver.cpp
@@ -1204,11 +1204,12 @@ void InterbotixDriverXS::init_operating_modes()
         // [0/false]: Normal Mode: CCW(Positive), CW(Negative)
         // [1/true]: Reverse Mode: CCW(Negative), CW(Positive)
         // This mode dictates how to calculate the homing offset of the shadow motor
-        std::bitset<8> shadow_drive_mode_bitset = shadow_drive_mode;
         int32_t homing_offset;
-        if (shadow_drive_mode_bitset.test(0)) {
+        if ((shadow_drive_mode & 0x01) == 0) {
+          // Normal Mode
           homing_offset = master_position - shadow_position;
         } else {
+          // Reverse Mode
           homing_offset = shadow_position - master_position;
         }
         dxl_wb.itemWrite(motor_map[shadow_name].motor_id, "Homing_Offset", homing_offset);


### PR DESCRIPTION
The current code incorrectly calculates the sign of the homing offset, leading to an exacerbation of the existing error rather than its correction. This issue is marked by the frequent overloading of elbow and shoulder motors. I found this bug when moving from ROS 1 to ROS 2.

In ROS 1, [the calibration procedure](https://github.com/Interbotix/interbotix_ros_core/blob/main/interbotix_ros_xseries/interbotix_xs_sdk/src/xs_sdk_obj.cpp#L794-L799) functions as expected. But it somehow gets broken in ROS 2's xs_driver. This PR fixes the calibration bug.